### PR TITLE
LORE-215 Fix Docker deploy step in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs: # Defines the overall Jobs for this particular pipeline to be used in work
       - run: echo "*PLACEHOLDER* pretending to execute integration testing phase!"
   Deploy Docker Image:
     docker:
-      - image: circleci/ruby:2.4.1
+      - image: *image
     steps:
       - run:
           name: Deploy to registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,7 @@ jobs: # Defines the overall Jobs for this particular pipeline to be used in work
     steps:
       - run: echo "*PLACEHOLDER* pretending to execute integration testing phase!"
   Deploy Docker Image:
-    docker:
-      - image: *image
+    docker: *image
     steps:
       - run:
           name: Deploy to registry


### PR DESCRIPTION
#### What does this PR do?

Small fix to change the image used to run the `mvn` command in the Deploy Docker Image step. The current `circleci/ruby:2.4.1` image apparently can't run Maven commands, so I'm changing it to `circleci/openjdk:11-jdk`.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
 @cjlange 
 @josephthweatt
 @brendan-hofmann
 @figliold
 @mcalcote

#### How should this be tested? (List steps with links to updated documentation)

This can't be tested until it gets merged into master 🤷‍♂.

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
