### PR TITLE
LORE-215 Fix Docker build and deploy step in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,10 +98,16 @@ jobs: # Defines the overall Jobs for this particular pipeline to be used in work
 # START: UNDER CONSTRUCTION AREA ---------------------------------------
 # TODO #1 - Get the docker image to build and flush out stage and commenting
   Docker Image Build: # Build-Container Image
-    docker:
-      - image: circleci/ruby:2.4.1
+    docker: *image
     steps:
-      - run: echo "*PLACEHOLDER* pretending to build a docker image!"
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: *env
+      - checkout
+      - run:
+          name: Build Docker image
+          command: |
+            mvn install -B -DskipTests $DISABLE_DOWNLOAD_PROGRESS_OPTS docker:build
   Container Scan:
     docker:
       - image: circleci/ruby:2.4.1
@@ -121,9 +127,9 @@ jobs: # Defines the overall Jobs for this particular pipeline to be used in work
     docker: *image
     steps:
       - run:
-          name: Deploy to registry
+          name: Deploy to internal registry
           command: |
-            mvn install -B docker:push
+            mvn docker:push
   Deploy Artifacts: # Deploy artifacts to Nexus or Maven Central
     docker:
       - image: circleci/ruby:2.4.1


### PR DESCRIPTION
#### What does this PR do?

I made a mistake in #21, but I couldn't confirm it until it got pushed to master. These changes add some additional steps and move the Docker build commands to the `Docker Image Build` job. I won't know if the `Deploy Docker Image` job will pass until it gets merged, but it would only be a small change if it doesn't.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
 @cjlange 
 @josephthweatt
 @brendan-hofmann
 @figliold
 @mcalcote

#### How should this be tested? (List steps with links to updated documentation)

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
