### PR TITLE
LORE-256 Implement transform delete endpoint

### DIFF
--- a/distros/spring/pom.xml
+++ b/distros/spring/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>guava</artifactId>
             <version>28.0-jre</version>
         </dependency>
+        <dependency>
+        <groupId>com.connexta.transformation</groupId>
+        <artifactId>commons-api</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/distros/spring/src/main/java/com/connexta/transformation/service/Application.java
+++ b/distros/spring/src/main/java/com/connexta/transformation/service/Application.java
@@ -16,9 +16,7 @@ package com.connexta.transformation.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.filter.CommonsRequestLoggingFilter;
 
 /**
@@ -50,11 +48,6 @@ public class Application {
   @Bean(name = "lookupServiceUrl")
   public String getLookupServiceUrl() {
     return lookupServiceUrl;
-  }
-
-  @Bean
-  public RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder.build();
   }
 
   public static void main(String[] args) {

--- a/distros/spring/src/main/java/com/connexta/transformation/service/DeleteController.java
+++ b/distros/spring/src/main/java/com/connexta/transformation/service/DeleteController.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.transformation.service;
+
+import com.connexta.transformation.commons.api.TransformationManager;
+import com.connexta.transformation.commons.api.exceptions.TransformationException;
+import com.connexta.transformation.commons.api.exceptions.TransformationNotFoundException;
+import com.connexta.transformation.rest.spring.TransformApiDelete;
+import io.swagger.annotations.ApiParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Implementation of the Transformation RESTful Delete service. This is the main entry point for all
+ * HTTP Delete requests.
+ */
+@RestController
+@CrossOrigin(origins = "*")
+public class DeleteController implements TransformApiDelete {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DeleteController.class);
+
+  public TransformationManager transformationManager;
+
+  @Autowired
+  public DeleteController(TransformationManager transformManager) {
+    this.transformationManager = transformManager;
+  }
+
+  /**
+   * Handles application/json DELETE transform requests to the /transform context. This method
+   * handles: - Deleting the given transformId. - If the transformId is not there, a
+   * TransformationException gets thrown. Returns an HTTP Status Code of 204 No Content on success;
+   * otherwise, an error status code.
+   *
+   * @param transformId - the unique ID of the transform resource
+   * @throws TransformationException if an error occurs while executing this method
+   * @throws TransformationNotFoundException if the transformId is not there
+   * @return the response of the request with the HTTP status code and the Content-Version
+   */
+  @Override
+  public ResponseEntity<Void> delete(
+      @ApiParam(value = "The ID of the transform request. ", required = true)
+          @PathVariable("TransformId")
+          String transformId)
+      throws TransformationException {
+    transformationManager.delete(transformId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/distros/spring/src/main/java/com/connexta/transformation/service/TransformController.java
+++ b/distros/spring/src/main/java/com/connexta/transformation/service/TransformController.java
@@ -13,16 +13,25 @@
  */
 package com.connexta.transformation.service;
 
+import com.connexta.transformation.commons.api.TransformationManager;
+import com.connexta.transformation.commons.api.exceptions.TransformationException;
+import com.connexta.transformation.rest.models.ErrorResponse;
 import com.connexta.transformation.rest.models.TransformRequest;
-import com.connexta.transformation.rest.springboot.TransformApi;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.MediaType;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,7 +45,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @RestController
 @CrossOrigin(origins = "*")
-public class TransformController implements TransformApi {
+public class TransformController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TransformController.class);
 
@@ -46,7 +55,19 @@ public class TransformController implements TransformApi {
 
   private final String lookupServiceUrl;
 
+  public TransformationManager transformationManager;
+
+  @Autowired
   public TransformController(
+      RestTemplateBuilder builder,
+      @Qualifier("lookupServiceUrl") String lookupServiceUrl,
+      TransformationManager transformManager) {
+    this(builder.build(), lookupServiceUrl);
+    this.transformationManager = transformManager;
+  }
+
+  @VisibleForTesting
+  TransformController(
       RestTemplate restTemplate, @Qualifier("lookupServiceUrl") String lookupServiceUrl) {
     Preconditions.checkNotNull(restTemplate, "Rest Template cannot be null.");
     Preconditions.checkNotNull(lookupServiceUrl, "Lookup Service Url cannot be null.");
@@ -59,13 +80,64 @@ public class TransformController implements TransformApi {
    * handles: - Validating the message - Forwarding the request to the service lookup service.
    * Returns an HTTP Status Code of 202 Accepted on success; otherwise, an error status code.
    */
+  @ApiOperation(
+      value = "Submit transformation request",
+      nickname = "transform",
+      notes =
+          "A request to transform resources into discovery metadata and other supporting products.",
+      tags = {"transform"})
+  @ApiResponses({
+    @ApiResponse(
+        code = 201,
+        message =
+            "The transformation request was accepted for processing. The URI for polling the status is returned in the Location header of the response. "),
+    @ApiResponse(
+        code = 400,
+        message =
+            "The client message could not be understood by the server due to invalid format or syntax.",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 401,
+        message = "The client could not be authenticated.",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 403,
+        message = "The client is not authorized.",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 500,
+        message =
+            "The server encountered an unexpected condition that prevented it from fulfilling the request.",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 501,
+        message =
+            "The requested API version is not supported and therefore not implemented. Possible codes reported are: - 501001 - Unable to parse *Accept-Version* - 501002 - The provided major version is no longer supported - 501003 - The provided major version is not yet supported by the server - 501004 - The provided minor version is not yet supported by the server ",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 200,
+        message = "Any other possible errors not currently known.",
+        response = ErrorResponse.class)
+  })
   @RequestMapping(
-      value = "/transform",
-      consumes = {MediaType.APPLICATION_JSON_VALUE},
-      method = RequestMethod.POST)
+      value = {"/transform"},
+      produces = {"application/json"},
+      consumes = {"application/json"},
+      method = {RequestMethod.POST})
   public ResponseEntity<Void> transform(
-      @RequestHeader(ACCEPT_VERSION) String acceptVersion,
-      @Valid @RequestBody TransformRequest transformRequest) {
+      @ApiParam(
+              value =
+                  "The API version used by the client to produce the REST message. The client must accept responses marked with any minor versions after this one. This implies that all future minor versions of the message are backward compatible with all previous minor versions of the same message. ",
+              required = true)
+          @RequestHeader(value = "Accept-Version", required = true)
+          String acceptVersion,
+      @ApiParam(
+              value =
+                  "A request to transform a file into discovery metadata and other supporting products.",
+              required = true)
+          @Valid
+          @RequestBody
+          TransformRequest transformRequest) {
     LOGGER.debug("{}: {}", ACCEPT_VERSION, acceptVersion);
     forwardRequest(transformRequest);
     return ResponseEntity.accepted().build();
@@ -77,5 +149,59 @@ public class TransformController implements TransformApi {
         restTemplate.postForEntity(lookupServiceUrl, transformRequest, String.class);
     LOGGER.debug(
         "HTTP response status code from lookup service: {}", response.getStatusCodeValue());
+  }
+
+  /**
+   * Handles application/json DELETE transform requests to the /transform context. This method
+   * handles: - Deleting the given transformId. - If the transformId is not there, a
+   * TransformationNotFoundException gets thrown. Returns an HTTP Status Code of 204 No Content on
+   * success; otherwise, an error status code.
+   */
+  @ApiOperation(
+      value = "Delete the transformation request",
+      nickname = "delete",
+      notes =
+          "After retrieving the output of the transformation, the client should call this endpoint to remove the request. ",
+      tags = {"transform"})
+  @ApiResponses({
+    @ApiResponse(code = 204, message = "The transformation request was successfully deleted."),
+    @ApiResponse(
+        code = 400,
+        message =
+            "The client message could not be understood by the server due to invalid format or syntax.",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 401,
+        message = "The client could not be authenticated.",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 403,
+        message = "The client is not authorized.",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 404,
+        message = "The transform request could not be found.",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 501,
+        message =
+            "The requested API version is not supported and therefore not implemented. Possible codes reported are: - 501001 - Unable to parse *Accept-Version* - 501002 - The provided major version is no longer supported - 501003 - The provided major version is not yet supported by the server - 501004 - The provided minor version is not yet supported by the server ",
+        response = ErrorResponse.class),
+    @ApiResponse(
+        code = 200,
+        message = "Any other possible errors not currently known.",
+        response = ErrorResponse.class)
+  })
+  @RequestMapping(
+      value = {"/transform/{TransformId}"},
+      produces = {"application/json"},
+      method = {RequestMethod.DELETE})
+  public ResponseEntity<Void> delete(
+      @ApiParam(value = "The ID of the transform request. ", required = true)
+          @PathVariable("TransformId")
+          String transformId)
+      throws TransformationException {
+    transformationManager.delete(transformId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/distros/spring/src/main/java/com/connexta/transformation/service/TransformController.java
+++ b/distros/spring/src/main/java/com/connexta/transformation/service/TransformController.java
@@ -14,15 +14,11 @@
 package com.connexta.transformation.service;
 
 import com.connexta.transformation.commons.api.TransformationManager;
-import com.connexta.transformation.commons.api.exceptions.TransformationException;
-import com.connexta.transformation.rest.models.ErrorResponse;
 import com.connexta.transformation.rest.models.TransformRequest;
+import com.connexta.transformation.rest.springboot.TransformApi;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,11 +27,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -45,7 +38,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @RestController
 @CrossOrigin(origins = "*")
-public class TransformController {
+public class TransformController implements TransformApi {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TransformController.class);
 
@@ -75,55 +68,7 @@ public class TransformController {
     this.lookupServiceUrl = lookupServiceUrl;
   }
 
-  /**
-   * Handles application/json POST transform requests to the /transform context. This method
-   * handles: - Validating the message - Forwarding the request to the service lookup service.
-   * Returns an HTTP Status Code of 202 Accepted on success; otherwise, an error status code.
-   */
-  @ApiOperation(
-      value = "Submit transformation request",
-      nickname = "transform",
-      notes =
-          "A request to transform resources into discovery metadata and other supporting products.",
-      tags = {"transform"})
-  @ApiResponses({
-    @ApiResponse(
-        code = 201,
-        message =
-            "The transformation request was accepted for processing. The URI for polling the status is returned in the Location header of the response. "),
-    @ApiResponse(
-        code = 400,
-        message =
-            "The client message could not be understood by the server due to invalid format or syntax.",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 401,
-        message = "The client could not be authenticated.",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 403,
-        message = "The client is not authorized.",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 500,
-        message =
-            "The server encountered an unexpected condition that prevented it from fulfilling the request.",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 501,
-        message =
-            "The requested API version is not supported and therefore not implemented. Possible codes reported are: - 501001 - Unable to parse *Accept-Version* - 501002 - The provided major version is no longer supported - 501003 - The provided major version is not yet supported by the server - 501004 - The provided minor version is not yet supported by the server ",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 200,
-        message = "Any other possible errors not currently known.",
-        response = ErrorResponse.class)
-  })
-  @RequestMapping(
-      value = {"/transform"},
-      produces = {"application/json"},
-      consumes = {"application/json"},
-      method = {RequestMethod.POST})
+  @Override
   public ResponseEntity<Void> transform(
       @ApiParam(
               value =
@@ -149,59 +94,5 @@ public class TransformController {
         restTemplate.postForEntity(lookupServiceUrl, transformRequest, String.class);
     LOGGER.debug(
         "HTTP response status code from lookup service: {}", response.getStatusCodeValue());
-  }
-
-  /**
-   * Handles application/json DELETE transform requests to the /transform context. This method
-   * handles: - Deleting the given transformId. - If the transformId is not there, a
-   * TransformationNotFoundException gets thrown. Returns an HTTP Status Code of 204 No Content on
-   * success; otherwise, an error status code.
-   */
-  @ApiOperation(
-      value = "Delete the transformation request",
-      nickname = "delete",
-      notes =
-          "After retrieving the output of the transformation, the client should call this endpoint to remove the request. ",
-      tags = {"transform"})
-  @ApiResponses({
-    @ApiResponse(code = 204, message = "The transformation request was successfully deleted."),
-    @ApiResponse(
-        code = 400,
-        message =
-            "The client message could not be understood by the server due to invalid format or syntax.",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 401,
-        message = "The client could not be authenticated.",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 403,
-        message = "The client is not authorized.",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 404,
-        message = "The transform request could not be found.",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 501,
-        message =
-            "The requested API version is not supported and therefore not implemented. Possible codes reported are: - 501001 - Unable to parse *Accept-Version* - 501002 - The provided major version is no longer supported - 501003 - The provided major version is not yet supported by the server - 501004 - The provided minor version is not yet supported by the server ",
-        response = ErrorResponse.class),
-    @ApiResponse(
-        code = 200,
-        message = "Any other possible errors not currently known.",
-        response = ErrorResponse.class)
-  })
-  @RequestMapping(
-      value = {"/transform/{TransformId}"},
-      produces = {"application/json"},
-      method = {RequestMethod.DELETE})
-  public ResponseEntity<Void> delete(
-      @ApiParam(value = "The ID of the transform request. ", required = true)
-          @PathVariable("TransformId")
-          String transformId)
-      throws TransformationException {
-    transformationManager.delete(transformId);
-    return ResponseEntity.noContent().build();
   }
 }

--- a/distros/spring/src/test/java/com/connexta/transformation/service/DeleteControllerTest.java
+++ b/distros/spring/src/test/java/com/connexta/transformation/service/DeleteControllerTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.transformation.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.connexta.transformation.commons.api.TransformationManager;
+import com.connexta.transformation.commons.api.exceptions.TransformationNotFoundException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(DeleteController.class)
+public class DeleteControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean TransformationManager tManager;
+
+  @MockBean(answer = Answers.RETURNS_MOCKS)
+  private RestTemplateBuilder restTemplateBuilder;
+
+  @Test
+  public void testDelete() throws Exception {
+    this.mockMvc.perform(delete("/transform/id123")).andExpect(status().isNoContent());
+    verify(tManager).delete(anyString());
+  }
+
+  @Test
+  public void testNotFoundDelete() throws Exception {
+    doThrow(new TransformationNotFoundException("Transformation [gibberish-ID] cannot be found"))
+        .when(tManager)
+        .delete(anyString());
+    assertThatThrownBy(() -> this.mockMvc.perform(delete("/transform/gibberish-ID")))
+        .hasCause(
+            new TransformationNotFoundException("Transformation [gibberish-ID] cannot be found"));
+  }
+}

--- a/distros/spring/src/test/java/com/connexta/transformation/service/TransformControllerTest.java
+++ b/distros/spring/src/test/java/com/connexta/transformation/service/TransformControllerTest.java
@@ -13,51 +13,90 @@
  */
 package com.connexta.transformation.service;
 
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.connexta.transformation.commons.api.TransformationManager;
+import com.connexta.transformation.commons.api.exceptions.TransformationNotFoundException;
 import com.connexta.transformation.rest.models.TransformRequest;
-import org.junit.Assert;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.client.ResourceAccessException;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = "endpoints.lookupService.url = http://localhost:")
-@ContextConfiguration
+@WebMvcTest(TransformController.class)
 public class TransformControllerTest {
-  private static final String ACCEPT_VERSION = "0.1.0";
 
-  @LocalServerPort private int port;
+  private static final String TEST_URI = "http://test:9000";
 
-  @Autowired private TestRestTemplate restTemplate;
+  private static final String ACCEPT_VERSION = "Accept-Version";
 
-  @Autowired private String lookupServiceUrl;
+  private static final String ACCEPT_VERSION_NUM = "0.1.0";
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean TransformationManager tManager;
+
+  @MockBean(answer = Answers.RETURNS_MOCKS)
+  private RestTemplateBuilder restTemplateBuilder;
 
   @Test
-  public void testAcceptedResponseEntity() {
-    TransformController controller =
-        new TransformController(restTemplate.getRestTemplate(), lookupServiceUrl + port);
-    ResponseEntity responseEntity = controller.transform(ACCEPT_VERSION, new TransformRequest());
-
-    Assert.assertThat(responseEntity.getStatusCode(), is(HttpStatus.ACCEPTED));
+  public void testAcceptedResponseEntity() throws Exception {
+    this.mockMvc
+        .perform(
+            post("/transform")
+                .header(ACCEPT_VERSION, ACCEPT_VERSION_NUM)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    mapper.writeValueAsString(
+                        new TransformRequest()
+                            .currentLocation(new URI(TEST_URI))
+                            .finalLocation(new URI(TEST_URI))
+                            .metacardLocation(new URI(TEST_URI))))
+                .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isAccepted());
   }
 
   @Test(expected = ResourceAccessException.class)
   public void testInvalidServiceUrl() {
     String badServiceUrl = "http://bad.url";
     TransformController controller =
-        new TransformController(restTemplate.getRestTemplate(), badServiceUrl);
+        new TransformController(new RestTemplateBuilder(), badServiceUrl, tManager);
 
     controller.transform(ACCEPT_VERSION, new TransformRequest());
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    this.mockMvc.perform(delete("/transform/id123")).andExpect(status().isNoContent());
+    verify(tManager).delete(anyString());
+  }
+
+  @Test
+  public void testNotFoundDelete() throws Exception {
+    doThrow(new TransformationNotFoundException("Transformation [gibberish-ID] cannot be found"))
+        .when(tManager)
+        .delete(anyString());
+    assertThatThrownBy(() -> this.mockMvc.perform(delete("/transform/gibberish-ID")))
+        .hasCause(
+            new TransformationNotFoundException("Transformation [gibberish-ID] cannot be found"));
   }
 }

--- a/distros/spring/src/test/java/com/connexta/transformation/service/TransformControllerTest.java
+++ b/distros/spring/src/test/java/com/connexta/transformation/service/TransformControllerTest.java
@@ -13,16 +13,10 @@
  */
 package com.connexta.transformation.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.connexta.transformation.commons.api.TransformationManager;
-import com.connexta.transformation.commons.api.exceptions.TransformationNotFoundException;
 import com.connexta.transformation.rest.models.TransformRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
@@ -82,21 +76,5 @@ public class TransformControllerTest {
         new TransformController(new RestTemplateBuilder(), badServiceUrl, tManager);
 
     controller.transform(ACCEPT_VERSION, new TransformRequest());
-  }
-
-  @Test
-  public void testDelete() throws Exception {
-    this.mockMvc.perform(delete("/transform/id123")).andExpect(status().isNoContent());
-    verify(tManager).delete(anyString());
-  }
-
-  @Test
-  public void testNotFoundDelete() throws Exception {
-    doThrow(new TransformationNotFoundException("Transformation [gibberish-ID] cannot be found"))
-        .when(tManager)
-        .delete(anyString());
-    assertThatThrownBy(() -> this.mockMvc.perform(delete("/transform/gibberish-ID")))
-        .hasCause(
-            new TransformationNotFoundException("Transformation [gibberish-ID] cannot be found"));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <transformation.api.version>0.2.0</transformation.api.version>
+        <transformation.api.version>0.3.0-SNAPSHOT</transformation.api.version>
         <slf4j.version>1.7.25</slf4j.version>
         <junit.jupiter.version>5.3.1</junit.jupiter.version>
 
@@ -297,6 +297,19 @@
                         <configuration>
                             <property>highest-basedir</property>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
#### What does this PR do?
Implements the business logic for the delete endpoint for the polling api

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@austinsteffes 
@brendan-hofmann
@brjeter 
@kcover 
@paouelle 

#### How should this be tested? (List steps with links to updated documentation)
CI

#### Any background context you want to provide?
It was suggested that instead of catching the exceptions within the endpoint methods themselves, we would create a class to handle all of those exceptions, in order to not duplicate code. Therefore, we now implement the newly separated API implementations (see this PR: https://github.com/connexta/ion-transformation-api/pull/59) in order to throw the exceptions. Some of this PR was just to update the code to work around this change. Also, there was discussion to handle the `Content-Version` in a separate PR. The actual delete method and units test are quite simple, but they are the main focus of this PR.

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
